### PR TITLE
Fix for WordPress OAuth server

### DIFF
--- a/DCTAuth/NSString+DCTAuth.m
+++ b/DCTAuth/NSString+DCTAuth.m
@@ -29,7 +29,6 @@
 			*stop = broken = YES;
 			return;
 		}
-		[dictionary setObject:[keyValueArray objectAtIndex:1] forKey:[keyValueArray objectAtIndex:0]];
 		[dictionary setObject:[keyValueArray objectAtIndex:1]
                                forKey:[[keyValueArray objectAtIndex:0] stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]]];
 	}];

--- a/DCTAuth/NSString+DCTAuth.m
+++ b/DCTAuth/NSString+DCTAuth.m
@@ -30,6 +30,8 @@
 			return;
 		}
 		[dictionary setObject:[keyValueArray objectAtIndex:1] forKey:[keyValueArray objectAtIndex:0]];
+		[dictionary setObject:[keyValueArray objectAtIndex:1]
+                               forKey:[[keyValueArray objectAtIndex:0] stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]]];
 	}];
 	if (broken) return nil;
 	return [dictionary copy];


### PR DESCRIPTION
WordPress http response to http://server/oauth1/request returns and additional CRLF between header and body. This leads to a dictionary having a key like `\noauth_token`.

Example:
```
HTTP/1.1 200 OK
Server: nginx/1.10.1
Date: Thu, 31 Aug 2017 14:55:24 GMT
Content-Type: application/x-www-form-urlencoded; charset=utf-8
Transfer-Encoding: chunked
Connection: close
X-Powered-By: PHP/7.0.3
Access-Control-Allow-Headers: Authorization


oauth_token=BtgsncIT13hQuTEWsV2kYjYo&oauth_token_secret=uJNSLX2rNdeIFYlZad2rVFgeqKU6c6bUkjA1T3bZSBUOiVxq&oauth_callback_confirmed=true
```

This pull request modifies the creation of the dictionary to remove leading CRLF in keys while creating the response parameter dictionary.

As much as I've tried to identify why this happens in WordPress side I've not been able to remove the extra CRLF there. I get some behaviour with Apache and nginx. Therefore, it might be useful to have this fix in DCTAuth.

Regards,

David Hernando